### PR TITLE
Allow configuration the domain where validator runs through ENV-variables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Convert to LF line endings on checkout.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,9 @@ ENV SERVICE_DOMAIN_OVERRIDE ""
 
 RUN mv /docker-entrypoint.sh /docker-entrypoint-jetty.sh
 COPY res/docker-entrypoint.sh /
+# Ensure the sh has permission to execute
+# Preventing: Error: crun: open executable: Permission denied: OCI permission denied
+RUN chmod +x /docker-entrypoint.sh
 
 # Inject the config properties file so we have a file to modify the domain at container build.
 # Otherwise the app will write a default properties file on startup.

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,20 @@ ENV HTTPS_PROXY_USERNAME none
 # Optional password for authenticating against HTTP Secure proxy server or "none"
 ENV HTTPS_PROXY_PASSWORD none
 
+# Config domain where the service runs
+# - empty string means current domain
+# - code defaults to http://localhost:8090
+# Affects (sed cmd in res/docker-entrypoint.sh):
+#  - /etf/validator/js/config.js
+#  - /etf/config/etf-config.properties
+ENV SERVICE_DOMAIN_OVERRIDE ""
+
 RUN mv /docker-entrypoint.sh /docker-entrypoint-jetty.sh
 COPY res/docker-entrypoint.sh /
+
+# Inject the config properties file so we have a file to modify the domain at container build.
+# Otherwise the app will write a default properties file on startup.
+COPY res/etf-config.properties $ETF_DIR/config/
 
 RUN apk add openrc --no-cache
 

--- a/res/docker-entrypoint.sh
+++ b/res/docker-entrypoint.sh
@@ -153,6 +153,16 @@ if [ ! -n "$ETF_RELATIVE_URL" ]; then
     ETF_RELATIVE_URL=etf-webapp
 fi
 
+# Change configured domain from http://localhost:8090 to ENV-variable value
+sed -i "s|http://localhost:8090|$SERVICE_DOMAIN_OVERRIDE|g" "$ETF_DIR/validator/js/config.js"
+
+# Modify the base URL which points to the deployed web application.
+# The URL is used to reference this ETF instance in the Test Reports.
+# Example: http://yourserver/etf-webapp
+# Default value is:
+#   etf.webapp.base.url = http://localhost:8090/validator
+sed -i "s|http://localhost:8090|$SERVICE_DOMAIN_OVERRIDE|g" "$ETF_DIR/config/etf-config.properties"
+
 # Download Webapp
 if [ ! -f "$appServerDeplPath/$ETF_RELATIVE_URL".war ]; then
     echo "Downloading ETF. This may take a while..."

--- a/res/etf-config.properties
+++ b/res/etf-config.properties
@@ -1,0 +1,150 @@
+#########################################
+# ETF CONFIGURATION PROPERTY FILE
+#########################################
+
+# Version of the property path, used for backward compatibility.
+# (do not modify unless you know what you are doing)
+etf.config.properties.version = 2
+
+
+#########################################
+## General properties
+#########################################
+
+# Modify the base URL which points to the deployed web application.
+# The URL is used to reference this ETF instance from the Test Reports.
+# Example: http://yourserver/etf-webapp
+etf.webapp.base.url = http://localhost:8090/validator
+
+# Restrict cross-origin HTTP requests for browsers, see
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# for more information.
+# Default: taken from etf.webapp.base.url
+etf.api.allow.origin = *
+
+# An optional branding text which is shown in the header
+etf.branding.text = INSPIRE Reference Validator
+
+
+# Max file upload size for test data in bytes.
+# By default the max upload size is estimated based on presumable free memory
+# during the start of the application.
+# Hint: 524288000 bytes are 500 MB
+# Default: auto
+etf.max.upload.size = 52428800
+
+# Maximum size of the Test Object data in bytes.
+# As compressed files can be uploaded and the maximum file upload size
+# is different from the size of the extracted test files, this property
+# ensures that the specified limit is not exceeded.
+# Default: 5368709120 (5 GB)
+# etf.testobject.max.size = 5368709120
+
+# Expiration time for temporary Test Objects. After the time has elapsed,
+# the test objects and test data are deleted.
+# To deactivate this feature and keep all Test Objects, the property
+# must be changed to the value 0.
+# Default: 480 (8 hours)
+# etf.testobject.temporary.lifetime.expiration = 480
+
+# Expiration time for Test Reports. After the time has elapsed,
+# the reports are deleted.
+# To deactivate this feature and keep all Test Reports, the property
+# must be changed to the value 0.
+# Default: 11520 (8 days)
+etf.testreports.lifetime.expiration = 4320
+
+# Allow access to private networks. Checked when
+# a new webservice test object is created. "false" is recommended in public
+# deployments.
+# Default: false
+# etf.testobject.allow.privatenet.access = false
+
+# Recreate the internal BaseX configuration file (.basex) on startup. "true" is
+# recommended.
+# Default: true
+# etf.bsx.recreate.config = true
+
+# Possible values default/simplified . A simplified workflow enables the user
+# to start a test run without creating a test object.
+# Default: simplified
+# etf.workflows = simplified
+
+# Maximum number of tests which can run in parallel.
+# Default: auto (the number of CPU cores of this machine)
+# etf.testruns.threads.max = auto
+
+# Size of the task pool queue
+# Default: auto (three times the parameter etf.testruns.threads.max)
+# etf.testruns.queued.max = auto
+
+##################################################################################
+## Contact, legal notice, privacy statement
+##################################################################################
+#
+# Please note: you can add multiple lines by using the \ character at the end
+# of the line.
+#
+
+# Contact
+# etf.meta.contact.text = <p>Operator A</p> \
+#                    <p>X Avenue</p> \
+#                    <p>Fort Lauderdale</p> \
+#                    <p>Broward County</p> \
+#                    <p>Florida, USA</p> \
+#                    <br>\
+#                    <p>Email: nielsen@a.com</p>
+
+# Disclaimer shown under Legal notice
+# etf.meta.legalnotice.disclaimer.text = Disclaimer ...
+
+# Copyright notice only shown under Legal notice if Disclaimer is set!
+# etf.meta.legalnotice.copyrightnotice.text = Copyright notice ...
+
+# Privacy statement
+# etf.meta.privacystatement.text = Privacy statement ...
+
+
+#########################################
+## Directory properties
+#########################################
+
+# For all directories, paths can be set that are either absolute or
+# relative to the etf.dir. If the etf.dir is not specified it is
+# set to ../ relative to this configuration file.
+
+# Optional base path
+# Default: ../
+# etf.dir=/data/etf
+
+# Directory for the test projects
+# Default: projects
+# etf.projects.dir = projects
+
+# Directory which contains the reports styles
+# Default: reportstyles
+# etf.reportstyles.dir = reportstyles
+
+# Directory which contains the test drivers
+# Default: td
+# etf.testdrivers.dir = td
+
+# Directory that the application uses for text data tests
+# Default: testdata
+# etf.testdata.dir = testdata
+
+# Directory for the internal data source
+# Default: ds
+# etf.datasource.dir = ds
+
+# Directory that the application uses to store uploaded files
+# Default: http_uploads
+# etf.testdata.upload.dir = http_uploads
+
+# Directory that the application uses to backup files
+# Default: bak
+# etf.backup.dir = bak
+
+etf.testdrivers.teamengine.url = http://cite.opengeospatial.org/teamengine
+etf.testdrivers.teamengine.username = 
+etf.testdrivers.teamengine.password = 


### PR DESCRIPTION
Uses sed in the docker-entrypoint.sh to change the hardcoded `http://localhost:8090` references to value that is configurable using the `SERVICE_DOMAIN_OVERRIDE` ENV-variable. The ENV-variable defaults to an empty url as only the frontend code seems to use the references. This should work for most instances without configuration since the browser then uses relative urls instead of the absolute paths including the configurable domain.

This requires the etf-config.properties to be included at build-time. Otherwise the webapp seems to initialize one with the default values and we can't modify it after the webapp is already running.

Also includes a [commit](https://github.com/inspire-eu-validation/INSPIRE-Validator-Container/commit/472f25c58358977a03f577d32dd370092683b988) to fix issues with file permissions and line-endings that I had when testing the build and running of the container.