### PR TITLE
Forward users to /validator path automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,11 @@ RUN touch /run/openrc/softlevel
 #RUN apk del curl libcurl wget y unzip y nano
 RUN apk add curl libcurl wget unzip nano
 
+# Add a dummy index page to guide users to the /validator path
+# For 8080 port
+COPY res/index.html /var/lib/jetty/webapps/ROOT/
+# For 8090 port
+COPY res/index.html /etf/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/res/index.html
+++ b/res/index.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="refresh" content="0; url=/validator" />
+    </head>
+<body>
+    <h1>Inspire validator</h1>
+    <p>
+        App runs on the <a href="/validator"><button>/validator</button></a> path.
+    </p>
+</body>
+</html>

--- a/res/index.html
+++ b/res/index.html
@@ -1,12 +1,12 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <meta http-equiv="refresh" content="0; url=/validator" />
+        <meta http-equiv="refresh" content="0; url=/validator/" />
     </head>
 <body>
     <h1>Inspire validator</h1>
     <p>
-        App runs on the <a href="/validator"><button>/validator</button></a> path.
+        App runs on the <a href="/validator/"><button>/validator/</button></a> path.
     </p>
 </body>
 </html>


### PR DESCRIPTION
Adds an html page as Jetty ROOT webapp and an index-document for httpd running on 8090 that forwards users accessing the domain directly to the /validator path so the users see the validator application instead of either of these:

### port 8090 
<img width="503" height="227" alt="Näyttökuva 2025-08-15 142237" src="https://github.com/user-attachments/assets/67e6a858-5c9b-4b66-9924-63d312f310f2" />

### port 8080
<img width="665" height="411" alt="Näyttökuva 2025-08-15 142357" src="https://github.com/user-attachments/assets/d9fdb01e-5a3a-46e8-add4-bf7afdf75216" />
