### PR TITLE
Update to latest Jetty 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:10.0.18-jre11-alpine-eclipse-temurin
+FROM jetty:10.0.25-jre11-alpine-eclipse-temurin
 MAINTAINER Guadaltel <guadaltel.com>
 LABEL maintainer="Guadaltel <inspire.jrc@guadaltel.com>"
 

--- a/res/docker-entrypoint.sh
+++ b/res/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Requires:
 # -unzip


### PR DESCRIPTION
- Update Jetty base image 10.0.18 -> 10.0.25
- The alpine base image also requires the change from `bash` to `sh` in `docker-entrypoint.sh`.