### PR TITLE
Disable jetty/apache version announcements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,11 @@ RUN touch /run/openrc/softlevel
 #RUN apk del curl libcurl wget y unzip y nano
 RUN apk add curl libcurl wget unzip nano
 
+# Config Jetty to not announce version
+RUN echo "jetty.httpConfig.sendServerVersion=false" >> /var/lib/jetty/start.ini
+# Config apache to not announce version
+RUN sed -i "s|ServerTokens OS|ServerTokens Prod|g" /etc/apache2/httpd.conf
+RUN sed -i "s|ServerSignature On|ServerSignature Off|g" /etc/apache2/httpd.conf
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["java","-jar","/usr/local/jetty/start.jar"]


### PR DESCRIPTION
Disables Jetty and Apache from declaring their versions on error pages and HTTP headers.